### PR TITLE
Docs: group publication research view by subdirection

### DIFF
--- a/docs/source/PublicationsByResearch.rst
+++ b/docs/source/PublicationsByResearch.rst
@@ -4,231 +4,168 @@
 建筑结构抗风
 ------------
 
-2026
-~~~~~~~~~~~~
+数值风洞与湍流入流
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`[74] A novel framework for urban geometry rapid reconstruction utilizing high-resolution stereo satellite imagery for wind environment assessment <ref-zhao2026-BE>` （数值风洞与湍流入流）
+- (2026) :ref:`[74] A novel framework for urban geometry rapid reconstruction utilizing high-resolution stereo satellite imagery for wind environment assessment <ref-zhao2026-BE>`
 
-- :ref:`[73] Numerical research on the impact of built-in rectangular poles on the dynamic characteristics of rectangular liquid tanks <ref-he2026-OE>` （高层建筑抗风与优化）
+- (2026) :ref:`[72] A fast prediction framework for urban microscale wind environment based on precomputed CFD database <ref-zhao2026-BS>`
 
-- :ref:`[72] A fast prediction framework for urban microscale wind environment based on precomputed CFD database <ref-zhao2026-BS>` （数值风洞与湍流入流）
+- (2026) :ref:`[70] A novel framework for temporal super-resolution of wind in urban energy applications <ref-tang2026-RE>`
 
-- :ref:`[70] A novel framework for temporal super-resolution of wind in urban energy applications <ref-tang2026-RE>` （数值风洞与湍流入流）
+- (2025) :ref:`[67] Evaluation of urban wind effects on flight path planning of delivery drones using computational fluid dynamics simulations <ref-wang2025-POF>`
 
-2025
-~~~~~~~~~~~~
+- (2025) :ref:`[61] A novel framework utilizing 3D Gaussian Splatting to construct building geometry for urban wind simulations <ref-zhao2025-SCS>`
 
-- :ref:`[69] Numerical investigation of nonlinear sloshing features and vibration mitigation efficiency of the implanted pole tuned liquid damper <ref-he2025-POF>` （高层建筑抗风与优化）
+- (2024) :ref:`[59] Comparing methods for reducing artificial pressure fluctuations using large eddy simulation in high-rise building wind load assessment <ref-chen2024-POF>`
 
-- :ref:`[68] Statistical extremes of 2D vectorial response for wind-excited tall buildings <ref-yang2025-JBE>` （高层建筑抗风与优化）
+- (2024) :ref:`[58] Super-resolution reconstruction of wind fields with a swin-transformer-based deep learning framework <ref-tang2024-POF>`
 
-- :ref:`[67] Evaluation of urban wind effects on flight path planning of delivery drones using computational fluid dynamics simulations <ref-wang2025-POF>` （数值风洞与湍流入流）
+- (2024) :ref:`[55] A new controllable weak recycling inflow turbulence generator for evaluating wind effects on building in LES <ref-wang2024-ES>`
 
-- :ref:`[64] Training and application of graph neural networks for predicting structural responses targeted at tall building structures <ref-tang2025-JBE>` （高层建筑抗风与优化）
+- (2024) :ref:`[53] Identification of no-fly zones for delivery drone path planning in various urban wind environments <ref-jiang2024-POF>`
 
-- :ref:`[62] Deep reinforcement learning-based active flow control for a tall building <ref-yan2025-POF>` （高层建筑抗风与优化）
+- (2024) :ref:`[51] A novel vector potential random flow generation method for synthesizing divergence-free homogeneous isotropic turbulence with arbitrary spectra <ref-li2024-POF>`
 
-- :ref:`[61] A novel framework utilizing 3D Gaussian Splatting to construct building geometry for urban wind simulations <ref-zhao2025-SCS>` （数值风洞与湍流入流）
+- (2024) :ref:`[50] A coherence-improved and mass-balanced inflow turbulence generation method for large eddy simulation <ref-chen2024-JCP>`
 
-2024
-~~~~~~~~~~~~
+- (2023) :ref:`[47] Multiscale simulation of the urban wind environment under typhoon weather conditions <ref-zhao2023-BS>`
 
-- :ref:`[59] Comparing methods for reducing artificial pressure fluctuations using large eddy simulation in high-rise building wind load assessment <ref-chen2024-POF>` （数值风洞与湍流入流）
+- (2023) :ref:`[46] Numerical study of flow characteristics of tornado-like vortices considering both swirl ratio and aspect ratio <ref-zhang2023-JWEIA>`
 
-- :ref:`[58] Super-resolution reconstruction of wind fields with a swin-transformer-based deep learning framework <ref-tang2024-POF>` （数值风洞与湍流入流）
+- (2023) :ref:`[43] Large eddy simulation of turbulent atmospheric boundary layer flow based on a synthetic volume forcing method <ref-wang2023-JWEIA>`
 
-- :ref:`[57] Engineering method for quantifying the coupling effect of transmission tower-line system under strong winds <ref-liu2024-JWEIA>` （高层建筑抗风与优化）
+- (2023) :ref:`[39] 基于数值风洞试验的核电厂微地形风场分析与验证 <ref-feng2023-HKXYGC>`
 
-- :ref:`[56] 中国共产党精神谱系视域下土木工程课程思政建设的探索与实践 <ref-li2024-DX>` （高层建筑抗风与优化）
+- (2022) :ref:`[36] Pedestrian level wind flow field of elevated tall buildings with dense tandem arrangement <ref-gao2022-BE>`
 
-- :ref:`[55] A new controllable weak recycling inflow turbulence generator for evaluating wind effects on building in LES <ref-wang2024-ES>` （数值风洞与湍流入流）
+- (2022) :ref:`[34] Consistency improved random flow generation method for large eddy simulation of atmospheric boundary layer <ref-chen2022-JWEIA>`
 
-- :ref:`[54] Numerical research on nonlinear liquid sloshing and vibration control performance of tuned liquid damper <ref-he2024-JBE>` （高层建筑抗风与优化）
+- (2022) :ref:`[32] DRLinFluids: An open-source Python platform of coupling deep reinforcement learning and OpenFOAM <ref-wang2022-POF>`
 
-- :ref:`[53] Identification of no-fly zones for delivery drone path planning in various urban wind environments <ref-jiang2024-POF>` （数值风洞与湍流入流）
+- (2021) :ref:`[26] Multiscale modelling of planetary boundary layer flow over complex terrain: implementation under near-neutral conditions <ref-zhao2021-EFM>`
 
-- :ref:`[51] A novel vector potential random flow generation method for synthesizing divergence-free homogeneous isotropic turbulence with arbitrary spectra <ref-li2024-POF>` （数值风洞与湍流入流）
+- (2021) :ref:`[25] New consideration of lateral boundary treatment for meso- and micro-scale nested PBL simulations over complex terrain <ref-zhao2021-AR>`
 
-- :ref:`[50] A coherence-improved and mass-balanced inflow turbulence generation method for large eddy simulation <ref-chen2024-JCP>` （数值风洞与湍流入流）
+- (2021) :ref:`[22] 基于NWP/CFD嵌套的复杂地形风场模拟研究 <ref-zhao2021-TYNXB>`
 
-- :ref:`[49] Dynamic Failure Mode Analysis for a Transmission Tower-Line System Induced by Strong Winds <ref-liu2024-E>` （高层建筑抗风与优化）
+- (2020) :ref:`[21] RANS simulation of horizontal homogeneous atmospheric boundary layer over rough terrains by an enriched canopy drag model <ref-li2020-JWEIA>`
 
-2023
-~~~~~~~~~~~~
+- (2019) :ref:`[17] Observed sub-hectometer-scale low level jets in surface-layer velocity profiles of landfalling typhoons <ref-li2019-JWEIA>`
 
-- :ref:`[47] Multiscale simulation of the urban wind environment under typhoon weather conditions <ref-zhao2023-BS>` （数值风洞与湍流入流）
+- (2018) :ref:`[12] 复杂地形下基于计算流体动力学的风速比计算 <ref-xiao2018-KXJSYGC>`
 
-- :ref:`[46] Numerical study of flow characteristics of tornado-like vortices considering both swirl ratio and aspect ratio <ref-zhang2023-JWEIA>` （数值风洞与湍流入流）
+- (2017) :ref:`[10] Effects of inflow conditions on mountainous/urban wind environment simulation <ref-li2017-BS>`
 
-- :ref:`[44] Estimation of dynamic wind forces on a steel lattice tower based on generalized wind force spectra <ref-zhang2023-S>` （高层建筑抗风与优化）
+- (2012) :ref:`[5] A revised empirical model and CFD simulations for 3D axisymmetric steady-state flows of downbursts and impinging jets <ref-li2012-JWEIA>`
 
-- :ref:`[43] Large eddy simulation of turbulent atmospheric boundary layer flow based on a synthetic volume forcing method <ref-wang2023-JWEIA>` （数值风洞与湍流入流）
+- (2012) :ref:`[4] 基于超越阈值概率的行人风环境数值评估 <ref-li2012-GCLX>`
 
-- :ref:`[41] Reconstruction of dynamic wind forces on a transmission steel lattice tower using aeroelastic wind tunnel test data <ref-zhang2023-ES>` （高层建筑抗风与优化）
+- (2009) :ref:`[1] 复杂地形风能评估的CFD方法 <ref-xiao2009-HNLGDXXB>`
 
-- :ref:`[39] 基于数值风洞试验的核电厂微地形风场分析与验证 <ref-feng2023-HKXYGC>` （数值风洞与湍流入流）
+高层建筑抗风与优化
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`[38] 基于首次超越破坏的输电塔强风易损性分析 <ref-zhao2023-GYJZ>` （高层建筑抗风与优化）
+- (2026) :ref:`[73] Numerical research on the impact of built-in rectangular poles on the dynamic characteristics of rectangular liquid tanks <ref-he2026-OE>`
 
-2022
-~~~~~~~~~~~~
+- (2025) :ref:`[69] Numerical investigation of nonlinear sloshing features and vibration mitigation efficiency of the implanted pole tuned liquid damper <ref-he2025-POF>`
 
-- :ref:`[36] Pedestrian level wind flow field of elevated tall buildings with dense tandem arrangement <ref-gao2022-BE>` （数值风洞与湍流入流）
+- (2025) :ref:`[68] Statistical extremes of 2D vectorial response for wind-excited tall buildings <ref-yang2025-JBE>`
 
-- :ref:`[35] Operational modal analysis and continuous dynamic monitoring of high‐rise building based on wireless distributed synchronized data acquisition system <ref-hu2022-SCHM>` （高层建筑抗风与优化）
+- (2025) :ref:`[64] Training and application of graph neural networks for predicting structural responses targeted at tall building structures <ref-tang2025-JBE>`
 
-- :ref:`[34] Consistency improved random flow generation method for large eddy simulation of atmospheric boundary layer <ref-chen2022-JWEIA>` （数值风洞与湍流入流）
+- (2025) :ref:`[62] Deep reinforcement learning-based active flow control for a tall building <ref-yan2025-POF>`
 
-- :ref:`[32] DRLinFluids: An open-source Python platform of coupling deep reinforcement learning and OpenFOAM <ref-wang2022-POF>` （数值风洞与湍流入流）
+- (2024) :ref:`[57] Engineering method for quantifying the coupling effect of transmission tower-line system under strong winds <ref-liu2024-JWEIA>`
 
-- :ref:`[30] Wind load investigation of self-supported lattice transmission tower based on wind tunnel tests <ref-zhang2022-ES>` （高层建筑抗风与优化）
+- (2024) :ref:`[56] 中国共产党精神谱系视域下土木工程课程思政建设的探索与实践 <ref-li2024-DX>`
 
-- :ref:`[29] Machine learning-enabled estimation of crosswind load effect on tall buildings <ref-lin2022-JWEIA>` （高层建筑抗风与优化）
+- (2024) :ref:`[54] Numerical research on nonlinear liquid sloshing and vibration control performance of tuned liquid damper <ref-he2024-JBE>`
 
-- :ref:`[28] Research on Equivalent Static Load of High-Rise/Towering Structures Based on Wind-Induced Responses <ref-yang2022-AS>` （高层建筑抗风与优化）
+- (2024) :ref:`[49] Dynamic Failure Mode Analysis for a Transmission Tower-Line System Induced by Strong Winds <ref-liu2024-E>`
 
-2021
-~~~~~~~~~~~~
+- (2023) :ref:`[44] Estimation of dynamic wind forces on a steel lattice tower based on generalized wind force spectra <ref-zhang2023-S>`
 
-- :ref:`[27] Aerodynamic characteristics of a square cylinder with corner fins <ref-wang2021-ABE>` （高层建筑抗风与优化）
+- (2023) :ref:`[41] Reconstruction of dynamic wind forces on a transmission steel lattice tower using aeroelastic wind tunnel test data <ref-zhang2023-ES>`
 
-- :ref:`[26] Multiscale modelling of planetary boundary layer flow over complex terrain: implementation under near-neutral conditions <ref-zhao2021-EFM>` （数值风洞与湍流入流）
+- (2023) :ref:`[38] 基于首次超越破坏的输电塔强风易损性分析 <ref-zhao2023-GYJZ>`
 
-- :ref:`[25] New consideration of lateral boundary treatment for meso- and micro-scale nested PBL simulations over complex terrain <ref-zhao2021-AR>` （数值风洞与湍流入流）
+- (2022) :ref:`[35] Operational modal analysis and continuous dynamic monitoring of high‐rise building based on wireless distributed synchronized data acquisition system <ref-hu2022-SCHM>`
 
-- :ref:`[24] Machine learning-based prediction of crosswind vibrations of rectangular cylinders <ref-lin2021-JWEIA>` （高层建筑抗风与优化）
+- (2022) :ref:`[30] Wind load investigation of self-supported lattice transmission tower based on wind tunnel tests <ref-zhang2022-ES>`
 
-- :ref:`[22] 基于NWP/CFD嵌套的复杂地形风场模拟研究 <ref-zhao2021-TYNXB>` （数值风洞与湍流入流）
+- (2022) :ref:`[29] Machine learning-enabled estimation of crosswind load effect on tall buildings <ref-lin2022-JWEIA>`
 
-2020
-~~~~~~~~~~~~
+- (2022) :ref:`[28] Research on Equivalent Static Load of High-Rise/Towering Structures Based on Wind-Induced Responses <ref-yang2022-AS>`
 
-- :ref:`[21] RANS simulation of horizontal homogeneous atmospheric boundary layer over rough terrains by an enriched canopy drag model <ref-li2020-JWEIA>` （数值风洞与湍流入流）
+- (2021) :ref:`[27] Aerodynamic characteristics of a square cylinder with corner fins <ref-wang2021-ABE>`
 
-2019
-~~~~~~~~~~~~
+- (2021) :ref:`[24] Machine learning-based prediction of crosswind vibrations of rectangular cylinders <ref-lin2021-JWEIA>`
 
-- :ref:`[17] Observed sub-hectometer-scale low level jets in surface-layer velocity profiles of landfalling typhoons <ref-li2019-JWEIA>` （数值风洞与湍流入流）
+- (2019) :ref:`[15] 超高层建筑风荷载的数值模拟 <ref-zhou2019-WHLGDXXB>`
 
-- :ref:`[15] 超高层建筑风荷载的数值模拟 <ref-zhou2019-WHLGDXXB>` （高层建筑抗风与优化）
+- (2018) :ref:`[14] Vortex induced vibration of an inclined finite-length square cylinder <ref-hu2018-EJMBF>`
 
-2018
-~~~~~~~~~~~~
+- (2013) :ref:`[7] Slope stability analysis based on measured strains along soil nails using FBG sensing technology <ref-pei2013-MPE>`
 
-- :ref:`[14] Vortex induced vibration of an inclined finite-length square cylinder <ref-hu2018-EJMBF>` （高层建筑抗风与优化）
+- (2010) :ref:`[3] Large eddy simulation of wind loads on a long-span spatial lattice roof <ref-li2010-WAS>`
 
-- :ref:`[12] 复杂地形下基于计算流体动力学的风速比计算 <ref-xiao2018-KXJSYGC>` （数值风洞与湍流入流）
-
-2017
-~~~~~~~~~~~~
-
-- :ref:`[10] Effects of inflow conditions on mountainous/urban wind environment simulation <ref-li2017-BS>` （数值风洞与湍流入流）
-
-2013
-~~~~~~~~~~~~
-
-- :ref:`[7] Slope stability analysis based on measured strains along soil nails using FBG sensing technology <ref-pei2013-MPE>` （高层建筑抗风与优化）
-
-2012
-~~~~~~~~~~~~
-
-- :ref:`[5] A revised empirical model and CFD simulations for 3D axisymmetric steady-state flows of downbursts and impinging jets <ref-li2012-JWEIA>` （数值风洞与湍流入流）
-
-- :ref:`[4] 基于超越阈值概率的行人风环境数值评估 <ref-li2012-GCLX>` （数值风洞与湍流入流）
-
-2010
-~~~~~~~~~~~~
-
-- :ref:`[3] Large eddy simulation of wind loads on a long-span spatial lattice roof <ref-li2010-WAS>` （高层建筑抗风与优化）
-
-- :ref:`[2] 开口空间结构表面风压分布规律研究 <ref-teng2010-GCKZYGJGZ>` （高层建筑抗风与优化）
-
-2009
-~~~~~~~~~~~~
-
-- :ref:`[1] 复杂地形风能评估的CFD方法 <ref-xiao2009-HNLGDXXB>` （数值风洞与湍流入流）
+- (2010) :ref:`[2] 开口空间结构表面风压分布规律研究 <ref-teng2010-GCKZYGJGZ>`
 
 海上漂浮风电
 ------------
 
-2026
-~~~~~~~~~~~~
+浮式风机系统一体化分析与优化
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`[71] Structural design and optimization of a novel semi-submersible floating offshore wind turbine platform using reinforced concrete <ref-he2026-OE-structural>` （浮式混凝土平台结构设计）
+- (2025) :ref:`[63] A synthetic approach for high-fidelity aerodynamic performance optimization of large-scale wind turbine blades based on hybrid deep learning networks <ref-gong2025-POF>`
 
-2025
-~~~~~~~~~~~~
+- (2025) :ref:`[60] Fatigue analysis of monopile-supported offshore wind turbine under varied supported conditions <ref-liang2025-OE>`
 
-- :ref:`[66] Evaluating equivalent static wave loads for a delta-shaped semi-submersible 10-MW wind turbine <ref-zheng2025-OE>` （数值风浪流水池）
+- (2024) :ref:`[52] Bilevel optimization of non-uniform offshore wind farm layout and cable routing for the refined LCOE using an enhanced PSO <ref-zhang2024-OE>`
 
-- :ref:`[65] 中心与偏心布置半潜风机动力特性的模型试验 <ref-zheng2025-QHDXXB>` （数值风浪流水池）
+- (2023) :ref:`[48] Evaluation of floating wind turbine substructure designs by using long-term dynamic optimization <ref-zhou2023-AE>`
 
-- :ref:`[63] A synthetic approach for high-fidelity aerodynamic performance optimization of large-scale wind turbine blades based on hybrid deep learning networks <ref-gong2025-POF>` （浮式风机系统一体化分析与优化）
+- (2023) :ref:`[45] Efficient optimization design method of jacket structures for offshore wind turbines <ref-zheng2023-MS>`
 
-- :ref:`[60] Fatigue analysis of monopile-supported offshore wind turbine under varied supported conditions <ref-liang2025-OE>` （浮式风机系统一体化分析与优化）
+- (2023) :ref:`[40] 半潜式浮式风机长期动力响应的全局敏感性分析 <ref-xiang2023-CBGC>`
 
-2024
-~~~~~~~~~~~~
+- (2023) :ref:`[37] 浮式风机动力系统的线性耦合动力学分析 <ref-zhou2023-CBGC>`
 
-- :ref:`[52] Bilevel optimization of non-uniform offshore wind farm layout and cable routing for the refined LCOE using an enhanced PSO <ref-zhang2024-OE>` （浮式风机系统一体化分析与优化）
+- (2022) :ref:`[31] Long term effect of operating loads on large monopile-supported offshore wind turbines in sand <ref-abdullahi2022-OE>`
 
-2023
-~~~~~~~~~~~~
+- (2021) :ref:`[23] Global sensitivity study on the semisubmersible substructure of a floating wind turbine: Manufacturing cost, structural properties and hydrodynamics <ref-zhou2021-OE>`
 
-- :ref:`[48] Evaluation of floating wind turbine substructure designs by using long-term dynamic optimization <ref-zhou2023-AE>` （浮式风机系统一体化分析与优化）
+- (2020) :ref:`[20] Importance of platform mounting orientation of Y-shaped semi-submersible floating wind turbines: A case study by using surrogate models <ref-zhou2020-RE>`
 
-- :ref:`[45] Efficient optimization design method of jacket structures for offshore wind turbines <ref-zheng2023-MS>` （浮式风机系统一体化分析与优化）
+- (2019) :ref:`[19] Wind energy harvesting performance of tandem circular cylinders with triangular protrusions <ref-hu2019-JOFAS>`
 
-- :ref:`[42] Wind tunnel and wave flume testing on directionality dynamic responses of a 10 MW Y-shaped semi-submersible wind turbine <ref-zheng2023-JRSE>` （数值风浪流水池）
+- (2019) :ref:`[18] High-solidity straight-bladed vertical axis wind turbine: Numerical simulation and validation <ref-peng2019-JWEIA>`
 
-- :ref:`[40] 半潜式浮式风机长期动力响应的全局敏感性分析 <ref-xiang2023-CBGC>` （浮式风机系统一体化分析与优化）
+- (2019) :ref:`[16] Structural Analysis of Large-Scale Vertical-Axis Wind Turbines, Part I: Wind Load Simulation <ref-lin2019-E>`
 
-- :ref:`[37] 浮式风机动力系统的线性耦合动力学分析 <ref-zhou2023-CBGC>` （浮式风机系统一体化分析与优化）
+- (2018) :ref:`[13] Optimization of blade pitch in H-rotor vertical axis wind turbines through computational fluid dynamics simulations <ref-li2018-AE>`
 
-2022
-~~~~~~~~~~~~
+- (2017) :ref:`[9] Passive Vibration Control of a Semi-Submersible Floating Offshore Wind Turbine <ref-li2017-AS>`
 
-- :ref:`[33] Dynamics of a Y-shaped semi-submersible floating wind turbine: a comparison of concrete and steel support structures <ref-li2022-SOS>` （浮式混凝土平台结构设计）
+- (2015) :ref:`[8] Applicability of Wake Models to Predictions of Turbine-Induced Velocity Deficit and Wind Farm Power Generation <ref-zhang2015-E>`
 
-- :ref:`[31] Long term effect of operating loads on large monopile-supported offshore wind turbines in sand <ref-abdullahi2022-OE>` （浮式风机系统一体化分析与优化）
+- (2013) :ref:`[6] 2.5D large eddy simulation of vertical axis wind turbine in consideration of high angle of attack flow <ref-li2013-RE>`
 
-2021
-~~~~~~~~~~~~
+浮式混凝土平台结构设计
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- :ref:`[23] Global sensitivity study on the semisubmersible substructure of a floating wind turbine: Manufacturing cost, structural properties and hydrodynamics <ref-zhou2021-OE>` （浮式风机系统一体化分析与优化）
+- (2026) :ref:`[71] Structural design and optimization of a novel semi-submersible floating offshore wind turbine platform using reinforced concrete <ref-he2026-OE-structural>`
 
-2020
-~~~~~~~~~~~~
+- (2022) :ref:`[33] Dynamics of a Y-shaped semi-submersible floating wind turbine: a comparison of concrete and steel support structures <ref-li2022-SOS>`
 
-- :ref:`[20] Importance of platform mounting orientation of Y-shaped semi-submersible floating wind turbines: A case study by using surrogate models <ref-zhou2020-RE>` （浮式风机系统一体化分析与优化）
+数值风浪流水池
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-2019
-~~~~~~~~~~~~
+- (2025) :ref:`[66] Evaluating equivalent static wave loads for a delta-shaped semi-submersible 10-MW wind turbine <ref-zheng2025-OE>`
 
-- :ref:`[19] Wind energy harvesting performance of tandem circular cylinders with triangular protrusions <ref-hu2019-JOFAS>` （浮式风机系统一体化分析与优化）
+- (2025) :ref:`[65] 中心与偏心布置半潜风机动力特性的模型试验 <ref-zheng2025-QHDXXB>`
 
-- :ref:`[18] High-solidity straight-bladed vertical axis wind turbine: Numerical simulation and validation <ref-peng2019-JWEIA>` （浮式风机系统一体化分析与优化）
+- (2023) :ref:`[42] Wind tunnel and wave flume testing on directionality dynamic responses of a 10 MW Y-shaped semi-submersible wind turbine <ref-zheng2023-JRSE>`
 
-- :ref:`[16] Structural Analysis of Large-Scale Vertical-Axis Wind Turbines, Part I: Wind Load Simulation <ref-lin2019-E>` （浮式风机系统一体化分析与优化）
-
-2018
-~~~~~~~~~~~~
-
-- :ref:`[13] Optimization of blade pitch in H-rotor vertical axis wind turbines through computational fluid dynamics simulations <ref-li2018-AE>` （浮式风机系统一体化分析与优化）
-
-2017
-~~~~~~~~~~~~
-
-- :ref:`[11] Directionality Effects of Aligned Wind and Wave Loads on a Y-Shape Semi-Submersible Floating Wind Turbine under Rated Operational Conditions <ref-zhou2017-E>` （数值风浪流水池）
-
-- :ref:`[9] Passive Vibration Control of a Semi-Submersible Floating Offshore Wind Turbine <ref-li2017-AS>` （浮式风机系统一体化分析与优化）
-
-2015
-~~~~~~~~~~~~
-
-- :ref:`[8] Applicability of Wake Models to Predictions of Turbine-Induced Velocity Deficit and Wind Farm Power Generation <ref-zhang2015-E>` （浮式风机系统一体化分析与优化）
-
-2013
-~~~~~~~~~~~~
-
-- :ref:`[6] 2.5D large eddy simulation of vertical axis wind turbine in consideration of high angle of attack flow <ref-li2013-RE>` （浮式风机系统一体化分析与优化）
+- (2017) :ref:`[11] Directionality Effects of Aligned Wind and Wave Loads on a Y-Shape Semi-Submersible Floating Wind Turbine under Rated Operational Conditions <ref-zhou2017-E>`

--- a/docs/superpowers/source-packets/2026-06-publications-zotero-snapshot.json
+++ b/docs/superpowers/source-packets/2026-06-publications-zotero-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-07T13:30:42.434562+00:00",
+  "generated_at": "2026-06-07T13:47:15.565167+00:00",
   "source_boundary": {
     "zotero_filter": {
       "inPublications": true,

--- a/scripts/update-publications-from-zotero.py
+++ b/scripts/update-publications-from-zotero.py
@@ -49,6 +49,10 @@ CSL_SHA256 = "fde99536c18e025299488fe4f65cd6269172d2274e1b48e877e64b24cd52aef1"
 
 METRIC_LABELS = ("影响因子", "中科院分区", "引用次数")
 RESEARCH_FAMILY_ORDER = ("建筑结构抗风", "海上漂浮风电")
+RESEARCH_SUBDIRECTION_ORDER = {
+    "建筑结构抗风": ("数值风洞与湍流入流", "高层建筑抗风与优化"),
+    "海上漂浮风电": ("浮式风机系统一体化分析与优化", "浮式混凝土平台结构设计", "数值风浪流水池"),
+}
 STUDENT_SECTION_MARKERS = ("PhD Students", "Master Students", "博士生", "硕士生")
 STUDENT_NAME_ALIASES = {
     "周盛涛": ["Zhou Shengtao", "Shengtao Zhou"],
@@ -598,6 +602,10 @@ def validate_research_map(items: list[dict[str, Any]], research_map: dict[str, d
         family = research_map[key].get("research_family", "")
         if family not in RESEARCH_FAMILY_ORDER:
             errors.append(f"{key} has invalid research_family: {family or '<missing>'}")
+            continue
+        subdirection = research_map[key].get("subdirection", "")
+        if subdirection not in RESEARCH_SUBDIRECTION_ORDER[family]:
+            errors.append(f"{key} has invalid subdirection for {family}: {subdirection or '<missing>'}")
 
     if errors:
         raise ZoteroError("\n".join(errors))
@@ -709,9 +717,9 @@ def build_publications_rst(items: list[dict[str, Any]]) -> str:
 def research_link_entry(item: dict[str, Any], research_map: dict[str, dict[str, str]]) -> str:
     title = " ".join(str(item["data"].get("title") or "Untitled").split())
     title = rst_escape(title)
-    subdirection = research_map[item["key"]].get("subdirection", "").strip()
-    suffix = f" （{subdirection}）" if subdirection else ""
-    return f"- :ref:`[{item['publication_number']}] {title} <{item['anchor']}>`{suffix}"
+    year = extract_year(item["data"].get("date"))
+    year_text = str(year) if year else "更早"
+    return f"- ({year_text}) :ref:`[{item['publication_number']}] {title} <{item['anchor']}>`"
 
 
 def build_publications_by_research_rst(
@@ -724,16 +732,13 @@ def build_publications_by_research_rst(
     ]
     for family in RESEARCH_FAMILY_ORDER:
         sections.extend([family, "-" * 12, ""])
-        current_year: int | None = None
-        for item in items:
-            if research_map[item["key"]]["research_family"] != family:
-                continue
-            year = extract_year(item["data"].get("date"))
-            if year != current_year:
-                current_year = year
-                title = str(year) if year else "更早 Early"
-                sections.extend([title, "~" * 12, ""])
-            sections.extend([research_link_entry(item, research_map), ""])
+        for subdirection in RESEARCH_SUBDIRECTION_ORDER[family]:
+            sections.extend([subdirection, "~" * 40, ""])
+            for item in items:
+                row = research_map[item["key"]]
+                if row["research_family"] != family or row.get("subdirection") != subdirection:
+                    continue
+                sections.extend([research_link_entry(item, research_map), ""])
     return "\n".join(sections).rstrip() + "\n"
 
 

--- a/tests/test_publications_research_view.py
+++ b/tests/test_publications_research_view.py
@@ -12,6 +12,10 @@ PUBLICATIONS_BY_RESEARCH = ROOT / "docs/source/PublicationsByResearch.rst"
 RESEARCH_MAP = ROOT / "docs/data/publication-research-map.json"
 
 RESEARCH_FAMILIES = ("建筑结构抗风", "海上漂浮风电")
+RESEARCH_STRUCTURE = {
+    "建筑结构抗风": ("数值风洞与湍流入流", "高层建筑抗风与优化"),
+    "海上漂浮风电": ("浮式风机系统一体化分析与优化", "浮式混凝土平台结构设计", "数值风浪流水池"),
+}
 
 
 def publication_anchors(text: str) -> set[str]:
@@ -22,6 +26,13 @@ def research_ref_targets(text: str) -> list[str]:
     return re.findall(r":ref:`[^`<]+ <(ref-[^>]+)>`", text)
 
 
+def section_between(text: str, title: str, next_titles: tuple[str, ...]) -> str:
+    start = text.index(f"\n{title}\n")
+    following = [text.index(f"\n{next_title}\n", start + 1) for next_title in next_titles if f"\n{next_title}\n" in text[start + 1 :]]
+    end = min(following) if following else len(text)
+    return text[start:end]
+
+
 class PublicationsResearchViewTests(unittest.TestCase):
     def test_publications_page_links_to_research_view(self) -> None:
         text = PUBLICATIONS.read_text(encoding="utf-8")
@@ -29,7 +40,7 @@ class PublicationsResearchViewTests(unittest.TestCase):
         self.assertIn("浏览方式 View Options", text)
         self.assertIn(":doc:`PublicationsByResearch`", text)
 
-    def test_research_view_groups_every_publication_by_family_then_descending_year(self) -> None:
+    def test_research_view_groups_every_publication_by_family_then_subdirection(self) -> None:
         publications_text = PUBLICATIONS.read_text(encoding="utf-8")
         research_text = PUBLICATIONS_BY_RESEARCH.read_text(encoding="utf-8")
 
@@ -41,12 +52,18 @@ class PublicationsResearchViewTests(unittest.TestCase):
         family_positions = [research_text.index(f"\n{family}\n") for family in RESEARCH_FAMILIES]
         self.assertEqual(family_positions, sorted(family_positions))
 
-        for family, start in zip(RESEARCH_FAMILIES, family_positions, strict=True):
-            next_positions = [pos for pos in family_positions if pos > start]
-            end = min(next_positions) if next_positions else len(research_text)
-            section = research_text[start:end]
-            years = [int(year) for year in re.findall(r"^(\d{4})$", section, flags=re.M)]
-            self.assertEqual(years, sorted(years, reverse=True), family)
+        for family, subdirections in RESEARCH_STRUCTURE.items():
+            other_families = tuple(candidate for candidate in RESEARCH_FAMILIES if candidate != family)
+            family_section = section_between(research_text, family, other_families)
+            subdirection_positions = [family_section.index(f"\n{subdirection}\n") for subdirection in subdirections]
+            self.assertEqual(subdirection_positions, sorted(subdirection_positions), family)
+            self.assertNotRegex(family_section, r"^\d{4}$", family)
+
+            for index, subdirection in enumerate(subdirections):
+                next_subdirections = subdirections[index + 1 :]
+                subdirection_section = section_between(family_section, subdirection, next_subdirections)
+                years = [int(year) for year in re.findall(r"^- \((\d{4})\) ", subdirection_section, flags=re.M)]
+                self.assertEqual(years, sorted(years, reverse=True), subdirection)
 
     def test_research_view_is_a_short_index_not_a_duplicate_bibliography(self) -> None:
         text = PUBLICATIONS_BY_RESEARCH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- group Publications by Research Direction under each research family by canonical subdirection
- render entries as short links prefixed with publication year
- update the Zotero generation script and regression test for the new structure

## Verification
- git diff --check main...HEAD
- ./scripts/check-docs.sh